### PR TITLE
Let the load generators scale linear

### DIFF
--- a/data-stream-generator/src/main/scala/ingest/ConstantRatePublisher.scala
+++ b/data-stream-generator/src/main/scala/ingest/ConstantRatePublisher.scala
@@ -60,7 +60,7 @@ class ConstantRatePublisher(sparkSession: SparkSession, kafkaProperties: Propert
       0.to(9).foreach { microBatch => //SUPPOSED TO LAST 100 MS
         smallGroupsList.foreach { smallList => //SUPPOSED TO LAST 5 MS
           smallList.foreach { observation =>
-            0.to(Math.round(ConfigUtils.dataVolume.toInt/3.0).toInt).foreach { volumeIteration =>
+            1.to(ConfigUtils.dataVolume).foreach { volumeIteration =>
               if (observation.message.contains("flow")) {
                 flowStats.mark()
                 val msg = new ProducerRecord[String, String](

--- a/data-stream-generator/src/main/scala/ingest/FaultyEventPublisher.scala
+++ b/data-stream-generator/src/main/scala/ingest/FaultyEventPublisher.scala
@@ -64,7 +64,7 @@ class FaultyEventPublisher(sparkSession: SparkSession, kafkaProperties: Properti
       0.to(9).foreach { microBatch => //SUPPOSED TO LAST 100 MS
         smallGroupsList.foreach { smallList => //SUPPOSED TO LAST 5 MS
           smallList.foreach { observation =>
-            0.to(Math.round(ConfigUtils.dataVolume.toInt / 3.0).toInt).foreach { volumeIteration =>
+            1.to(ConfigUtils.dataVolume).foreach { volumeIteration =>
               if (sendError & index == 0 & ConfigUtils.publisherNb.toInt == 1) { // at minute 15 send an error
                 val msg = new ProducerRecord[String, String](
                   ConfigUtils.flowTopic,

--- a/data-stream-generator/src/main/scala/ingest/SingleBurstPublisher.scala
+++ b/data-stream-generator/src/main/scala/ingest/SingleBurstPublisher.scala
@@ -78,7 +78,7 @@ class SingleBurstPublisher(sparkSession: SparkSession, kafkaProperties: Properti
       0.to(9).foreach { microBatch => //SUPPOSED TO LAST 100 MS
         smallGroupsList.foreach { smallList => //SUPPOSED TO LAST 5 MS
           smallList.foreach { observation: Observation =>
-            0.to(Math.round(volume/3.0).toInt).foreach { volumeIteration =>
+            1.to(ConfigUtils.dataVolume).foreach { volumeIteration =>
               if (observation.message.contains("flow")) {
                 flowStats.mark()
                 val msg = new ProducerRecord[String, String](

--- a/data-stream-generator/src/main/scala/ingest/SingleBurstPublisher.scala
+++ b/data-stream-generator/src/main/scala/ingest/SingleBurstPublisher.scala
@@ -78,7 +78,7 @@ class SingleBurstPublisher(sparkSession: SparkSession, kafkaProperties: Properti
       0.to(9).foreach { microBatch => //SUPPOSED TO LAST 100 MS
         smallGroupsList.foreach { smallList => //SUPPOSED TO LAST 5 MS
           smallList.foreach { observation: Observation =>
-            1.to(ConfigUtils.dataVolume).foreach { volumeIteration =>
+            1.to(volume).foreach { volumeIteration =>
               if (observation.message.contains("flow")) {
                 flowStats.mark()
                 val msg = new ProducerRecord[String, String](


### PR DESCRIPTION
The load generator divided the data volume by three and rounded the result.
Thus, e.g., for load 2, 3, and 4 the same number of iterations are
performed and result in the same produced data rate.
Now the data volume is taken and not divided.
Further, the data volume starts at one to produce data to have a
ratio scale and data volume of 0 is the absolute zero.

Further, the describe data volume in the Wiki is not correct. The `StreamProducer` call 3 times the `publish` method and yielded a throughput of 1140 for data volume 0 and both streams.

With the proposed change the new throughput is: 
throughput = 1140 * DATA_VOLUME
or for one Data Stream:
throughput = 570 * DATA_VOLUME